### PR TITLE
Bugfix: add thread limitation to annotation function

### DIFF
--- a/LST_AI/annotate.py
+++ b/LST_AI/annotate.py
@@ -26,7 +26,7 @@ from skimage.morphology import binary_dilation
 
 
 def annotate_lesions(atlas_t1, atlas_mask, t1w_native, seg_native, out_atlas_warp,
-                     out_atlas_mask_warped, out_annotated_native):
+                     out_atlas_mask_warped, out_annotated_native, n_threads=8):
     """
     Annotate lesions in a given image using an atlas.
 
@@ -66,6 +66,7 @@ def annotate_lesions(atlas_t1, atlas_mask, t1w_native, seg_native, out_atlas_war
         f"greedy -d 3 -m WNCC 2x2x2 -sv -n 100x50x10"
         f" -i {t1w_native} {atlas_t1}"
         f" -o {out_atlas_warp}"
+        f" -threads {n_threads}"
     )
     subprocess.run(shlex.split(deformable_call), check=True)
 
@@ -74,6 +75,7 @@ def annotate_lesions(atlas_t1, atlas_mask, t1w_native, seg_native, out_atlas_war
         f"greedy -d 3 -rf {t1w_native} -ri LABEL 0.2vox"
         f" -rm {atlas_mask} {out_atlas_mask_warped}"
         f" -r {out_atlas_warp}"
+        f" -threads {n_threads}"
     )
 
     subprocess.run(shlex.split(warp_call), check=True)
@@ -136,7 +138,8 @@ if __name__ == "__main__":
                      seg_native=seg_native_path,
                      out_atlas_warp=out_atlas_warp_path,
                      out_atlas_mask_warped=out_atlas_mask_warped_path,
-                     out_annotated_native=annotated_seg_path)
+                     out_annotated_native=annotated_seg_path,
+                     n_threads=6)
 
     # check and remove testing results
     gt = os.path.join(parent_directory, "testing", "annotation",

--- a/LST_AI/lst
+++ b/LST_AI/lst
@@ -265,7 +265,8 @@ if __name__ == "__main__":
                          seg_native=path_orig_segmentation,
                          out_atlas_warp=atlas_warp,
                          out_atlas_mask_warped=atlas_mask_warped,
-                         out_annotated_native=path_orig_annotated_segmentation)
+                         out_annotated_native=path_orig_annotated_segmentation,
+                         n_threads=args.threads)
 
         shutil.copy(path_orig_annotated_segmentation,
                     os.path.join(args.output, filename_output_annotated_segmentation))
@@ -404,7 +405,8 @@ if __name__ == "__main__":
                              seg_native=path_mni_segmentation,
                              out_atlas_warp=atlas_warp,
                              out_atlas_mask_warped=atlas_mask_warped,
-                             out_annotated_native=path_mni_annotated_segmentation)
+                             out_annotated_native=path_mni_annotated_segmentation,
+                             n_threads=args.threads)
 
             # warp results back to original FLAIR space
             apply_warp_label(image_org_space=path_org_stripped_flair,


### PR DESCRIPTION
Current LST-AI Version limits the threads for some of the greedy calls, but not in the annotation function. Let's change that! :slightly_smiling_face: 