### PR TITLE
Harmonize qform/sform of inputs to avoid mislocated segmentation (#44)

### DIFF
--- a/LST_AI/lst
+++ b/LST_AI/lst
@@ -20,7 +20,7 @@ from LST_AI.register import mni_registration, rigid_reg, apply_warp_label, apply
 from LST_AI.segment import unet_segmentation
 from LST_AI.annotate import annotate_lesions
 from LST_AI.stats import compute_stats
-from LST_AI.utils import download_data
+from LST_AI.utils import download_data, harmonize_affines
 
 if __name__ == "__main__":
 
@@ -148,6 +148,17 @@ if __name__ == "__main__":
         # make temp directory in case it does not exist
         if not os.path.exists(work_dir):
             os.makedirs(work_dir)
+
+    # Harmonize the qform and sform of the inputs before anything reads them.
+    # nibabel (used throughout this pipeline) prefers the sform, while greedy
+    # reads the qform; if a prior co-registration updated only the sform, the two
+    # disagree and the segmentation is mislocated. See issue #44.
+    harmonized_t1 = os.path.join(work_dir, 'input_T1w.nii.gz')
+    harmonized_flair = os.path.join(work_dir, 'input_FLAIR.nii.gz')
+    harmonize_affines(args.t1, harmonized_t1)
+    harmonize_affines(args.flair, harmonized_flair)
+    args.t1 = harmonized_t1
+    args.flair = harmonized_flair
 
     #  Define Image Paths (original space)
     path_org_t1w = os.path.join(work_dir, 'sub-X_ses-Y_space-t1w_T1w.nii.gz')

--- a/LST_AI/utils.py
+++ b/LST_AI/utils.py
@@ -3,6 +3,30 @@ import os
 import zipfile
 from urllib import request
 
+import nibabel as nib
+
+
+def harmonize_affines(input_path, output_path):
+    """Save ``input_path`` to ``output_path`` with its qform and sform set to the
+    same (nibabel-resolved) affine.
+
+    A NIfTI file stores two affines. ``nibabel`` (and therefore the rest of this
+    pipeline) reads ``img.affine``, which prefers the sform when ``sform_code > 0``,
+    while ``greedy`` (used for registration) reads the qform. When an earlier
+    co-registration step (e.g. in SPM) updates only the sform, the two disagree
+    and the resulting segmentation is mislocated in FLAIR space. Setting both
+    forms to ``img.affine`` keeps every downstream tool consistent. When the two
+    forms already agree this is a no-op. See
+    https://github.com/CompImg/LST-AI/issues/44.
+    """
+    img = nib.load(input_path)
+    affine = img.affine
+    code = int(img.header["sform_code"]) or int(img.header["qform_code"]) or 1
+    img.set_qform(affine, code=code)
+    img.set_sform(affine, code=code)
+    nib.save(img, output_path)
+
+
 def download_data(path):
     """
     Downloads required model weights, binaries and atlas files for usage.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,50 @@
+import os
+import tempfile
+
+import nibabel as nib
+import numpy as np
+
+from LST_AI.utils import harmonize_affines
+
+
+def _write(path, qform, sform):
+    img = nib.Nifti1Image(np.zeros((4, 4, 4), dtype=np.float32), affine=np.eye(4))
+    img.set_qform(qform, code=1)
+    img.set_sform(sform, code=2)
+    nib.save(img, path)
+
+
+def test_harmonize_affines_resolves_qform_sform_mismatch():
+    # Reproduces issue #44: an SPM-style co-registration updates only the sform,
+    # so qform != sform. After harmonization both must equal nibabel's resolved
+    # affine (the sform), so greedy (qform) and nibabel (sform) agree.
+    with tempfile.TemporaryDirectory() as d:
+        src, dst = os.path.join(d, "in.nii.gz"), os.path.join(d, "out.nii.gz")
+        sform = np.eye(4)
+        sform[:3, 3] = [10, -5, 3]
+        _write(src, qform=np.eye(4), sform=sform)
+
+        resolved = nib.load(src).affine  # nibabel prefers the sform
+        harmonize_affines(src, dst)
+        out = nib.load(dst)
+
+        assert np.allclose(out.affine, resolved)
+        assert np.allclose(out.get_qform(), resolved)
+        assert np.allclose(out.get_sform(), resolved)
+        assert np.allclose(out.get_qform(), out.get_sform())
+
+
+def test_harmonize_affines_noop_when_consistent():
+    # When qform == sform the data and affine are unchanged.
+    with tempfile.TemporaryDirectory() as d:
+        src, dst = os.path.join(d, "in.nii.gz"), os.path.join(d, "out.nii.gz")
+        affine = np.eye(4)
+        affine[:3, 3] = [1, 2, 3]
+        _write(src, qform=affine, sform=affine)
+
+        harmonize_affines(src, dst)
+        out = nib.load(dst)
+
+        assert np.allclose(out.affine, affine)
+        assert np.allclose(out.get_qform(), out.get_sform())
+        assert np.allclose(out.get_fdata(), nib.load(src).get_fdata())


### PR DESCRIPTION
## Problem (#44)

A NIfTI stores two affines. The pipeline reads images with nibabel's `img.affine`, which prefers the **sform** when `sform_code > 0`, but `greedy` (registration) reads the **qform**. When an earlier co-registration (e.g. SPM) updates only the sform, the two disagree, so the warped/annotated mask is mislocated in FLAIR space. The reporter confirmed that setting `qform = sform` resolves it.

Quick demonstration of the divergence:

```python
import numpy as np, nibabel as nib
img = nib.Nifti1Image(np.zeros((4, 4, 4), np.float32), np.eye(4))
img.set_qform(np.eye(4), code=1)
sf = np.eye(4); sf[:3, 3] = [10, -5, 3]; img.set_sform(sf, code=2)
img.affine[:3, 3]       # [10, -5, 3]  (nibabel / this pipeline: sform)
img.get_qform()[:3, 3]  # [0,  0,  0]  (greedy: qform)
```

## Fix

Add `harmonize_affines()` (in `utils.py`) and call it once on the `--t1`/`--flair` inputs, right after the work dir is created, before any tool reads them. It sets both the qform and sform to nibabel's resolved affine, so `greedy` and nibabel agree. It is a **no-op when the two forms already match**, so existing inputs are unaffected.

## Tests

Added `tests/test_utils.py`: one test reproducing the SPM-style mismatch (asserts `qform == sform ==` resolved affine after harmonization), one asserting it is a no-op (data + affine unchanged) when the forms already agree. Both pass.

Note: I validated the affine harmonization in isolation; I do not have a `greedy`/GPU setup to run the full pipeline end-to-end, so a sanity check on a real mismatched scan would be worth confirming. The fix matches the reporter's verified `qform = sform` workaround.

---
*Disclosure: authored with AI assistance (Claude Code); reviewed by me.*