### PR TITLE
CI: macOS import job; Docker release workflow skips without credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,17 @@ on:
 
 jobs:
   import-and-unit:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false          # one Python version failing should not mask the other
+      fail-fast: false          # one platform failing should not mask the others
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.10", "3.12"]
+        # One Apple Silicon leg: macOS has no CI-tested end-to-end run, but this at
+        # least guarantees the package and the network construct there continuously.
+        include:
+          - os: macos-14
+            python-version: "3.12"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -30,9 +36,15 @@ jobs:
       - name: Install (CPU torch, no CUDA wheels)
         # Deliberately without `onnx`: it became an optional extra in v2.0.0, so this
         # job doubles as the check that nothing on the inference path still imports it.
+        # The cpu wheel index is a Linux concern; on macOS the PyPI torch already is
+        # the CPU/MPS build, and the cpu index has no macOS wheels.
         run: |
           python -m pip install --upgrade pip
-          pip install --index-url https://download.pytorch.org/whl/cpu torch
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            pip install torch
+          else
+            pip install --index-url https://download.pytorch.org/whl/cpu torch
+          fi
           pip install numpy scipy scikit-image nibabel pytest
       - name: Import the package without the heavy extras
         # picsl-greedy and hd-bet are not needed to construct or exercise the network,

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,27 @@ env:
   IMAGE: jqmcginnis/lst-ai
 
 jobs:
+  # Secrets cannot be read in a job-level `if`, so a preflight job turns their
+  # presence into an output. On a repository without the DOCKERHUB_* secrets (e.g.
+  # upstream until its owner adds them) the whole workflow skips green instead of
+  # failing red at the login step.
+  creds:
+    runs-on: ubuntu-latest
+    outputs:
+      ok: ${{ steps.check.outputs.ok }}
+    steps:
+      - id: check
+        run: |
+          if [ -n "${{ secrets.DOCKERHUB_USERNAME }}" ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN not configured; skipping the push."
+          fi
+
   build-push:
+    needs: creds
+    if: needs.creds.outputs.ok == 'true'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -67,7 +87,8 @@ jobs:
           if-no-files-found: error
 
   manifest:
-    needs: build-push
+    needs: [creds, build-push]
+    if: needs.creds.outputs.ok == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Two release-readiness tweaks ahead of v2.0.0rc1:

- **macos-14 leg in import-and-unit** (Python 3.12): continuously verifies the package installs and the network constructs on Apple Silicon. No end-to-end mac run exists yet — this is the cheap continuous floor under a future one. torch installs from PyPI on macOS (the cpu wheel index is Linux-only).
- **docker.yml skips green when `DOCKERHUB_*` secrets are absent** (preflight job — secrets are not readable in a job-level `if`). A release published here before the owner adds Docker Hub credentials no longer produces a red run; the image push runs from the fork in the meantime.